### PR TITLE
feat: 게시글 라우트 분리 및 목록/노출 기능 개선

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -21,6 +21,10 @@
         </template>
 
         <template v-else>
+          <!-- 기부글 쓰기: 관리자 or 단체 계정일 때만 -->
+  <a-menu-item v-if="isAdmin || isOrganization" key="create-post">
+    <router-link to="/posts/create">기부글 쓰기</router-link>
+  </a-menu-item>
           <template v-if="isAdmin">
             <a-menu-item key="admin">
               <router-link to="/admin">관리자 페이지</router-link>
@@ -56,12 +60,12 @@ const route = useRoute()
 const selectedKey = ref('home')
 
 const auth = useAuthStore()
-const { isLoggedIn, isAdmin } = storeToRefs(auth) // 반응형 참조
+const { isLoggedIn, isAdmin, isOrganization } = storeToRefs(auth) // 반응형 참조
 
 
 // 라우팅에 따라 메뉴 선택
 watch(() => route.path, (path) => {
-  if (path.startsWith('/donations')) selectedKey.value = 'donate'
+  if (path.startsWith('/posts/create')) selectedKey.value = 'create-post'
   else if (path.startsWith('/login')) selectedKey.value = 'login'
   else if (path.startsWith('/signup')) selectedKey.value = 'signup'
   else if (path.startsWith('/mypage')) selectedKey.value = 'mypage'

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -7,8 +7,8 @@
         <a-menu-item key="home">
           <router-link to="/">홈</router-link>
         </a-menu-item>
-        <a-menu-item key="donate">
-          <router-link to="/donations">기부하기</router-link>
+        <a-menu-item key="posts">
+          <router-link to="/posts">기부하기</router-link>
         </a-menu-item>
 
         <template v-if="!isLoggedIn">
@@ -65,7 +65,8 @@ const { isLoggedIn, isAdmin, isOrganization } = storeToRefs(auth) // 반응형 �
 
 // 라우팅에 따라 메뉴 선택
 watch(() => route.path, (path) => {
-  if (path.startsWith('/posts/create')) selectedKey.value = 'create-post'
+  if (path.startsWith('/posts')) selectedKey.value = 'posts'
+  else if (path.startsWith('/posts/create')) selectedKey.value = 'create-post'
   else if (path.startsWith('/login')) selectedKey.value = 'login'
   else if (path.startsWith('/signup')) selectedKey.value = 'signup'
   else if (path.startsWith('/mypage')) selectedKey.value = 'mypage'

--- a/src/router/board.js
+++ b/src/router/board.js
@@ -1,0 +1,22 @@
+// 게시판 관련 라우트
+export const boardRoutes = [
+  {
+    path: '/posts/create',
+    name: 'createPost',
+    component: () => import('@/views/board/PostCreateView.vue'),
+    meta: { requiresAuth: true, roles: ['ADMIN', 'ORGANIZATION'] }
+  },
+  {
+    path: '/posts/:id',
+    name: 'postDetail',
+    component: () => import('@/views/board/PostDetailView.vue'),
+    props: true,
+  },
+  {
+    path: '/posts/:id/edit',
+    name: 'postEdit',
+    component: () => import('@/views/board/PostEditView.vue'),
+    props: true,
+    meta: { requiresAuth: true, roles: ['ADMIN', 'ORGANIZATION'] } // 필요 시
+  },
+]

--- a/src/router/board.js
+++ b/src/router/board.js
@@ -17,6 +17,11 @@ export const boardRoutes = [
     name: 'postEdit',
     component: () => import('@/views/board/PostEditView.vue'),
     props: true,
-    meta: { requiresAuth: true, roles: ['ADMIN', 'ORGANIZATION'] } // 필요 시
+    meta: { requiresAuth: true, roles: ['ADMIN', 'ORGANIZATION'] }
+  },
+  {
+    path: '/posts',
+    name: 'postList',
+    component: () => import('@/views/board/PostListView.vue')
   },
 ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import SignupView from '@/views/member/SignupView.vue'
 import LoginView from '@/views/member/LoginView.vue'
 import MyPageView from '@/views/member/MyPageView.vue'
 import { useAuthStore } from '@/stores/auth'
+import { boardRoutes } from './board.js'
 import { adminRoutes } from './admin.js'
 import { paymentRoutes } from './payment.js'
 
@@ -16,11 +17,6 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: MainPage,
-    },
-    {
-      path: '/posts/create',
-      name: 'createPost',
-      component: () => import('@/views/board/PostCreateView.vue')
     },
     {
       path: '/signup',
@@ -37,18 +33,6 @@ const router = createRouter({
       name: 'mypage',
       component: MyPageView
     },
-    {
-      path: '/posts/:id',
-      name: 'postDetail',
-      component: () => import('@/views/board/PostDetailView.vue'),
-      props: true,
-    },
-    {
-      path: '/posts/:id/edit',
-      name: 'postEdit',
-      component: () => import('@/views/board/PostEditView.vue'),
-      props: true
-    },
     // 특정 에러 타입별 라우트
     {
       path: '/error/:type',
@@ -63,6 +47,9 @@ const router = createRouter({
       component: () => import('@/views/error/ErrorPage.vue'),
       props: { errorType: '404' }
     },
+
+    // 게시판 관련 라우트
+    ...boardRoutes,
 
     // 결제 관련 라우트
     ...paymentRoutes,

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -24,7 +24,8 @@ export const useAuthStore = defineStore('auth', {
   }),
   getters: {
     isLoggedIn: (state) => !!state.accessToken,
-    isAdmin: (state) => state.user?.role === 'ADMIN'
+    isAdmin: (state) => state.user?.role === 'ADMIN',
+    isOrganization: (state) => state.user?.role === 'ORGANIZATION'
   },
   actions: {
     // 로그인 성공 시 호출
@@ -34,7 +35,7 @@ export const useAuthStore = defineStore('auth', {
         return
       }
       this.accessToken = token.replace(/^Bearer\s+/i, '')
-      
+
       // JWT에서 사용자 정보 추출
       const decodedToken = decodeJWT(token)
       if (decodedToken) {

--- a/src/stores/counter.js
+++ b/src/stores/counter.js
@@ -42,16 +42,23 @@ const donations = ref([])
     return computed(() => donations.value.find(item => item.id === Number(id)))
   }
 
-  // API로 데이터 가져오기
-async function fetchDonations() {
-  console.log('fetchDonations 호출됨')
+// 메인용 6개: 공개 + 마감임박
+async function fetchDonationsHome() {
   try {
-    const data = await api.get('/api/posts')
-    console.log('API 응답:', data)
+    const data = await api.get('/api/posts/home')  // 백엔드에서 6개만 내려주도록 구현
     donations.value = data
-    console.log('store.donations 갱신됨:', donations.value)
   } catch (err) {
-    console.error('기부 데이터 가져오기 실패:', err)
+    console.error('기부 데이터(메인) 가져오기 실패:', err)
+  }
+}
+
+// 전체 공개글
+async function fetchDonationsAll() {
+  try {
+    const data = await api.get('/api/posts')       // 전체 공개글
+    donations.value = data
+  } catch (err) {
+    console.error('기부 데이터(전체) 가져오기 실패:', err)
   }
 }
 
@@ -69,6 +76,7 @@ async function fetchDonations() {
     totalDonationAll,
     totalDonationFiltered,
     setCategory, clearCategory,
-    fetchDonations,
+    fetchDonationsHome,
+    fetchDonationsAll,
   }
 })

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -34,7 +34,7 @@ function goDetail(id) {
 // 페이지 로드시 API 호출
 onMounted(() => {
   console.log('메인페이지 onMounted 실행됨')
-  store.fetchDonations()
+  store.fetchDonationsHome()
 })
 
 // 카테고리 목록 (그대로)

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -88,7 +88,7 @@ const categories = [
           @click="goDetail(item.id)"
           style="cursor:pointer"
         >
-          <img :src="item.image" class="donation-image" />
+          <img :src="item.image || 'https://placehold.co/300x180'" class="donation-image" />
 
           <div class="donation-text">
             <div class="category">#{{ item.category }}</div>

--- a/src/views/board/PostDetailView.vue
+++ b/src/views/board/PostDetailView.vue
@@ -93,13 +93,19 @@ onMounted(fetchPostDetail)
 
     <div class="main-row">
       <div class="main-left">
-        <a-carousel autoplay style="width:100%;border-radius:16px;">
-          <div v-for="(img, idx) in post.imageUrls" :key="idx">
-            <div class="img-wrap">
-              <img class="main-img" :src="img" />
-            </div>
-          </div>
-        </a-carousel>
+        <a-carousel v-if="post.imageUrls && post.imageUrls.length" autoplay style="width:100%;border-radius:16px;">
+  <div v-for="(img, idx) in post.imageUrls" :key="idx">
+    <div class="img-wrap">
+      <img class="main-img" :src="img || 'https://placehold.co/300x180'" />
+    </div>
+  </div>
+</a-carousel>
+
+<!-- fallback -->
+<div v-else class="img-wrap">
+  <img class="main-img" src="https://placehold.co/300x180" />
+</div>
+
       </div>
       <div class="main-right">
         <div class="progress-card">

--- a/src/views/board/PostListView.vue
+++ b/src/views/board/PostListView.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { onMounted } from 'vue'
+import { useCounterStore } from '@/stores/counter'
+import { storeToRefs } from 'pinia'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const store = useCounterStore()
+const { donations } = storeToRefs(store)
+
+// 전체 공개글 로드
+onMounted(() => {
+  store.fetchDonationsAll()
+})
+
+// 상세 이동
+function goDetail(id) {
+  router.push({ name: 'postDetail', params: { id } })
+}
+</script>
+
+<template>
+  <div style="max-width:1100px;margin:24px auto;padding:0 12px;">
+
+    <a-row :gutter="16">
+      <a-col
+        v-for="item in donations"
+        :key="item.id"
+        :xs="24"
+        :sm="12"
+        :md="8"
+        :lg="6"
+      >
+        <a-card
+          hoverable
+          class="custom-card"
+          :bordered="false"
+          @click="goDetail(item.id)"
+          style="cursor:pointer"
+        >
+          <img :src="item.image || 'https://placehold.co/300x180'" class="donation-image" />
+          <div class="donation-text">
+            <div class="category">#{{ item.category }}</div>
+            <div class="title">{{ item.title }}</div>
+            <a-progress
+              :percent="item.percent"
+              :stroke-color="'#00C851'"
+              :show-info="false"
+              style="margin-top: 10px"
+            />
+            <div class="bottom-info">
+              <span class="remaining">마감까지 {{ (item.target - item.raised).toLocaleString() }}원</span>
+              <span class="percent">{{ ((item.raised / item.target) * 100).toFixed(1) }}%</span>
+            </div>
+          </div>
+        </a-card>
+      </a-col>
+    </a-row>
+  </div>
+</template>
+
+<style scoped>
+.custom-card { padding:0; overflow:hidden; border-radius:12px; box-shadow:0 6px 12px rgba(0,0,0,.15); margin-bottom:24px; }
+.donation-image { width:100%; height:180px; object-fit:cover; border-top-left-radius:12px; border-top-right-radius:12px; }
+.donation-text { padding:12px 16px; background:#fff; }
+.category { color:#00C851; font-weight:700; margin-bottom:4px; font-size:.9rem; }
+.title { font-size:1rem; font-weight:600; margin-bottom:8px; }
+.bottom-info { display:flex; justify-content:space-between; margin-top:4px; color:#777; font-size:.85rem; }
+.percent { color:#00C851; font-weight:700; }
+</style>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#4 
## ✅ 작업 내용
- board 관련 라우트 분리
- 메인페이지에 마감 임박 공개 기부글 6개만 노출되도록 수정
- 헤더 '기부하기' 버튼 클릭 시 전체 공개 게시글 목록 페이지 연결
## 리뷰 요구사항 (선택)

## 기타 (선택)
- 전체 게시글 목록 페이지는 기본적인 UI만 적용된 상태입니다. 추후 검색/필터 기능을 추가할 예정입니다.