### PR TITLE
fix: 취소할 때 paymentKey만 보내도록 수정

### DIFF
--- a/src/views/payment/PaymentHistoryView.vue
+++ b/src/views/payment/PaymentHistoryView.vue
@@ -131,7 +131,7 @@
             type="primary"
             danger
             size="small"
-            @click="cancelPayment(payment.paymentKey || payment.orderId)"
+            @click="cancelPayment(payment.paymentKey)"
             class="cancel-button"
           >
             취소


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#29 
## ✅ 작업 내용
- 결제 취소할 때 paymentKey만 보내도록 수정
## 리뷰 요구사항 (선택)

## 기타 (선택)